### PR TITLE
Enable Memcache module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -74,6 +74,7 @@ module:
   link: 0
   media: 0
   media_library: 0
+  memcache: 0
   menu_link_content: 0
   menu_ui: 0
   mysql: 0


### PR DESCRIPTION
Memcache module enable for cache.backend.memcache service.

Jira: [JCOREX-388](https://jira.highwire.org/browse/JCOREX-388)